### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ const imageResp = await fetch("https://github.com/EqualMa.png");
 const imageSize = parseInt(imageResp.headers.get("Content-Length"));
 
 Readable.from([
-  { headers: { name: "README.md" }, content: "# tar-transform" },
+  { headers: { name: "./README.md" }, content: "# tar-transform" },
   { headers: { name: "hello/world.txt" }, content: "Hello World!" },
   { headers: { name: "emptyDir", type: "directory" } },
   {
-    headers: { name: "author-avatar.png" },
+    headers: { name: "./author-avatar.png" },
     stream: imageResp.body,
   },
 ])


### PR DESCRIPTION
I just wasted hours trying to make `npm` read my tar file but it wasn't downloading files that don't start with `./`, it's probably a bug in npm but this can be useful for anyone trying to do the same thing as me